### PR TITLE
CRDL-414:Create a Bruno collection for crdl-cache-stub

### DIFF
--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-AcoActionNotPossibleReasonCode-Data.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-AcoActionNotPossibleReasonCode-Data.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get-AcoActionNotPossibleReasonCode-Data
+  type: http
+  seq: 4
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC03
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-All-Codelists.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-All-Codelists.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get-All-Codelists
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists
+  body: none
+  auth: inherit
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-CountryCode-Data-with-keys.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-CountryCode-Data-with-keys.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get-CountryCode-Data-with-keys
+  type: http
+  seq: 6
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC08?keys=AD,AE
+  body: none
+  auth: none
+}
+
+params:query {
+  keys: AD,AE
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-CountryCode-Data.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-CountryCode-Data.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get-CountryCode-Data
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC08
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-EvidenceTypeCode-Data.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-EvidenceTypeCode-Data.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get-EvidenceTypeCode-Data
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC01
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-ExciseProductCode-Data-With-Keys-And-Properties.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-ExciseProductCode-Data-With-Keys-And-Properties.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get-ExciseProductCode-Data-With-Keys-And-Properties
+  type: http
+  seq: 8
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC36?keys=B000,E200,E300&exciseProductsCategoryCode=E&alcoholicStrengthApplicabilityFlag=false
+  body: none
+  auth: none
+}
+
+params:query {
+  keys: B000,E200,E300
+  exciseProductsCategoryCode: E
+  alcoholicStrengthApplicabilityFlag: false
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-ExciseProductCode-Data-With-Properties.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-ExciseProductCode-Data-With-Properties.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get-ExciseProductCode-Data-With-Properties
+  type: http
+  seq: 9
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC36?unitOfMeasureCode=2&exciseProductsCategoryCode=E&alcoholicStrengthApplicabilityFlag=false
+  body: none
+  auth: none
+}
+
+params:query {
+  unitOfMeasureCode: 2
+  exciseProductsCategoryCode: E
+  alcoholicStrengthApplicabilityFlag: false
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-PackagingType-with-keys-And-Properties.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-PackagingType-with-keys-And-Properties.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Get-PackagingType-with-keys-And-Properties
+  type: http
+  seq: 7
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC17?keys=1A,1B&countableFlag=true
+  body: json
+  auth: none
+}
+
+params:query {
+  keys: 1A,1B
+  countableFlag: true
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}
+
+body:json {
+  {
+    "keys": ["1A","1B"],
+    "properties": {
+      "countableFlag": true
+    }
+  }
+  
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/Get-RefusalReasonCode-Data.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/Get-RefusalReasonCode-Data.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get-RefusalReasonCode-Data
+  type: http
+  seq: 5
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/lists/BC09
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Codelist/folder.bru
+++ b/.bruno/CRDL-CACHE-STUB/Codelist/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Codelist
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-All-Query-Params.bru
+++ b/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-All-Query-Params.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get-Customs-Office-With-All-Query-Params
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/offices?roles=AUT,DEP&referenceNumbers=AD000001&countryCodes=AD
+  body: none
+  auth: inherit
+}
+
+params:query {
+  roles: AUT,DEP
+  referenceNumbers: AD000001
+  countryCodes: AD
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-CountryCode.bru
+++ b/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-CountryCode.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get-Customs-Office-With-CountryCode
+  type: http
+  seq: 4
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/offices?countryCodes=FR,DE
+  body: none
+  auth: inherit
+}
+
+params:query {
+  countryCodes: FR,DE
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-ReferenceNumber.bru
+++ b/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-ReferenceNumber.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get-Customs-Office-With-ReferenceNumber
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/offices?referenceNumbers=HU511010
+  body: none
+  auth: inherit
+}
+
+params:query {
+  referenceNumbers: HU511010
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-Roles.bru
+++ b/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office-With-Roles.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get-Customs-Office-With-Roles
+  type: http
+  seq: 5
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/offices?roles=AUT,DEP
+  body: none
+  auth: inherit
+}
+
+params:query {
+  roles: AUT,DEP
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office.bru
+++ b/.bruno/CRDL-CACHE-STUB/Customs Office/Get-Customs-Office.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get-Customs-Office
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:7254/crdl-cache/offices
+  body: none
+  auth: inherit
+}
+
+headers {
+  Authorization: crdl-cache-stub
+}

--- a/.bruno/CRDL-CACHE-STUB/Customs Office/folder.bru
+++ b/.bruno/CRDL-CACHE-STUB/Customs Office/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Customs Office
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/.bruno/CRDL-CACHE-STUB/bruno.json
+++ b/.bruno/CRDL-CACHE-STUB/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "CRDL-CACHE-STUB",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 !.gitignore
 !.scalafmt.conf
+!.bruno
 bin
 .bloop/
 .cache


### PR DESCRIPTION
Created a Bruno collection to make it easy to quickly access query URLs and query parameters for future developers. To open the collection in Bruno, either clone this repo or download/copy just the .bruno file. In Bruno, choose Open File. You may need to show hidden files to see the folder (on Mac use Shift+Cmd+.). Then navigate to CRDL-CACHE-STUB and open the file.