### PR TITLE
Upgrade libraries: sbt-plugin → 3.0.10, bootstrap-backend-play-30 → 10.6.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import play.core.PlayVersion
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.5.0"
+  private val bootstrapVersion = "10.6.0"
   private val hmrcMongoVersion = "2.12.0"
 
   val compile = Seq(


### PR DESCRIPTION
## Library Upgrades

| Group | Artifact | New Version |
|-------|----------|-------------|
| `org.playframework` | `sbt-plugin` | `3.0.10` |
| `uk.gov.hmrc` | `bootstrap-backend-play-30` | `10.6.0` |